### PR TITLE
test: 테스트 커버리지 확보를 위한 테스트 코드 추가 13 - 12.31

### DIFF
--- a/src/test/java/com/sprint/mission/discodeit/controller/MessageControllerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/controller/MessageControllerTest.java
@@ -211,4 +211,25 @@ public class MessageControllerTest {
             .andExpect(jsonPath("$.content[0].channelId").value(channelId.toString()))
             .andExpect(jsonPath("$.content[0].content").value("hi"));
     }
+
+    @Test
+    @DisplayName("POST /api/messages에서 messageCreateRequest 파트가 없으면 500이 반환된다")
+    void createMessage_missingMultipart() throws Exception {
+        // given: multipart 요청이지만 필수 파트가 없음
+
+        // when & then
+        mockMvc.perform(multipart("/api/messages")
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("GET /api/messages에서 channelId가 없으면 500이 반환된다")
+    void getMessages_missingChannelId() throws Exception {
+        // given: 필수 파라미터 없이 호출
+
+        // when & then
+        mockMvc.perform(get("/api/messages"))
+            .andExpect(status().isInternalServerError());
+    }
 }


### PR DESCRIPTION
## 주요 변경사항
- 기존 테스트 클래스에 테스트 메서드 추가
- 원본 S3BinaryContentStorageTest 분기를 덮기 위해 MockedStatic(S3Client/S3Presigner)로 빌더 호출을 가로채 예외 흐름을 강제로 실행


