### PR TITLE
fix: SocialAccount 조회시 user를 fetch join하게 수정 및 카카오 로그인위한 설정

### DIFF
--- a/src/main/java/com/sprint/mission/discodeit/config/SecurityConfig.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                 .requestMatchers("/ws/**").permitAll()
                 .requestMatchers("/auth/social/**").permitAll()
                 .requestMatchers("/auth/callback").permitAll()
+                .requestMatchers("/google.svg", "/kakao.svg").permitAll()
 
                 // 테스트용 - 캐시 테스트 엔드포인트 허용
                 .requestMatchers("/api/test/cache/**").permitAll()

--- a/src/main/java/com/sprint/mission/discodeit/repository/SocialAccountRepository.java
+++ b/src/main/java/com/sprint/mission/discodeit/repository/SocialAccountRepository.java
@@ -5,8 +5,18 @@ import com.sprint.mission.discodeit.entity.SocialProvider;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, UUID> {
 
-    Optional<SocialAccount> findByProviderAndProviderUserId(SocialProvider provider, String providerUserId);
+    @Query("""
+    select sa from SocialAccount sa
+    join fetch sa.user u
+    left join fetch u.profile
+    where sa.provider = :provider
+      and sa.providerUserId = :providerUserId
+    """)
+    Optional<SocialAccount> findByProviderAndProviderUserIdWithUser(
+        SocialProvider provider, String providerUserId
+    );
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -122,4 +122,4 @@ oauth:
       token-url: https://kauth.kakao.com/oauth/token
       user-info-url: https://kapi.kakao.com/v2/user/me
       redirect-url: ${OAUTH_KAKAO_REDIRECT_URL:http://localhost:8080/auth/social/callback/kakao}
-      scope: "account_email profile_nickname"
+      scope: "profile_nickname"


### PR DESCRIPTION
## 주요 변경사항
- SocialAccount 조회시 user를 fetch join하게 수정
- 카카오 로그인 개발 용으로 scope에서 account_email 제거
- findOrCreateUser 메서드에서 별도로 email 계산하도록 수정

## 스크린 샷

<img width="764" height="893" alt="kakao OAuth" src="https://github.com/user-attachments/assets/a9dd2943-e31e-4fc5-b0a1-16443f1063e1" />
