### PR TITLE
test: 이벤트 리스너 테스트 멱등/구조 변경 반영

### DIFF
--- a/src/test/java/com/sprint/mission/discodeit/event/BinaryContentEventListenerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/event/BinaryContentEventListenerTest.java
@@ -19,7 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
-class BinaryContentEventListenerTest {
+public class BinaryContentEventListenerTest {
 
     @Mock private BinaryContentStorage binaryContentStorage;
     @Mock private BinaryContentService binaryContentService;

--- a/src/test/java/com/sprint/mission/discodeit/event/DistributedSseEventListenerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/event/DistributedSseEventListenerTest.java
@@ -12,40 +12,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 @ExtendWith(MockitoExtension.class)
 public class DistributedSseEventListenerTest {
 
     @Mock private SseService sseService;
-    @Mock private KafkaTemplate<String, Object> kafkaTemplate;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private DistributedSseEventListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new DistributedSseEventListener(sseService, kafkaTemplate, objectMapper);
+        listener = new DistributedSseEventListener(sseService, objectMapper);
     }
 
     @Test
-    @DisplayName("로그인/로그아웃 이벤트는 Kafka에 JSON 페이로드로 발행된다")
-    void handleUserLogInOutForKafka_shouldPublishPayload() throws Exception {
-        // given
-        UserLogInOutEvent event = UserLogInOutEvent.logIn(UUID.randomUUID());
-
-        // when
-        listener.handleUserLogInOutForKafka(event);
-
-        // then
-        then(kafkaTemplate).should().send(
-            "discodeit.UserLogInOutEvent",
-            objectMapper.writeValueAsString(event)
-        );
-    }
-
-    @Test
-    @DisplayName("Kafka Consumer는 페이로드를 역직렬화하여 SSE로 브로드캐스트한다")
+    @DisplayName("Kafka Consumer 페이로드를 역직렬화하여 SSE로 브로드캐스트한다")
     void handleUserLogInOutFromKafka_shouldBroadcast() throws Exception {
         // given
         UserLogInOutEvent event = UserLogInOutEvent.logOut(UUID.randomUUID());

--- a/src/test/java/com/sprint/mission/discodeit/event/NotificationRequiredEventListenerTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/event/NotificationRequiredEventListenerTest.java
@@ -26,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-class NotificationRequiredEventListenerTest {
+public class NotificationRequiredEventListenerTest {
 
     @Mock private NotificationService notificationService;
     @Mock private ReadStatusRepository readStatusRepository;


### PR DESCRIPTION
## 주요 변경사항
- DistributedSseEventListener producer 제거에 맞춰 테스트 정리
- KafkaNotificationEventListener 멱등 처리 로직에 맞춰 Redis 스텁/검증 추가
- 이벤트 리스너 테스트의 실패 케이스/불필요 스텁 정리
